### PR TITLE
chore: update readme and make hermes benchmark better

### DIFF
--- a/benchmark-hermes.sh
+++ b/benchmark-hermes.sh
@@ -22,5 +22,5 @@ scenarios_to_run=("${all_scenarios_in_directory[@]}")
 # For each one - listen to stdout and append it to ./results/run_id.csv. There should only be one line of output per scenario.
 for file in "${scenarios_to_run[@]}"; do
     echo "$file"
-    gtime /Users/tylerwilliams/build_release/bin/node-hermes ./build/node/"$(basename "$file")"
+    gtime node-hermes ./build/node/"$(basename "$file")"
 done


### PR DESCRIPTION
Update the readme, update `node-hermes` to use just the command name itself.