### PR TITLE
fix: bundle the node code for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "webpack-cli": "^5.1.4"
   },
   "scripts": {
-    "build:web": "webpack --config webpack.config.cjs",
-    "test:node": "node ./runners/node-runner.js | tee ./results/node-results.csv",
+    "build": "rm -rf build/* && webpack --config webpack.config.cjs",
+    "test:node": "npm run build && node ./build/index.node.bundle.js | tee ./results/node-results.csv",
     "test:hermes": "echo 'Hermes not yet supported'",
-    "test:web": "npm run build:web && node ./puppeteer/puppeteer.cjs | tee ./results/web-results.csv"
+    "test:web": "npm run build && node ./puppeteer/puppeteer.cjs | tee ./results/web-results.csv"
   }
 }

--- a/puppeteer/puppeteer.cjs
+++ b/puppeteer/puppeteer.cjs
@@ -22,7 +22,7 @@ const fs = require("fs").promises;
     "utf-8"
   );
   const indexBundleScript = await fs.readFile(
-    "./puppeteer/index.bundle.js",
+    "../build/index.web.bundle.js",
     "utf-8"
   );
 

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,11 +1,22 @@
 const path = require("path");
 
-module.exports = {
-  entry: "./runners/web-runner.js",
-  output: {
-    filename: "index.bundle.js",
-    path: path.resolve(__dirname, "puppeteer"),
+module.exports = [
+  {
+    entry: "./runners/web-runner.js",
+    output: {
+      filename: "index.web.bundle.js",
+      path: path.resolve(__dirname, "build"),
+    },
+    target: "web",
+    mode: "production",
   },
-  target: "web",
-  mode: "production",
-};
+  {
+    entry: "./runners/node-runner.js",
+    output: {
+      filename: "index.node.bundle.js",
+      path: path.resolve(__dirname, "build"),
+    },
+    target: "node",
+    mode: "production",
+  },
+];


### PR DESCRIPTION
Closes #15. Initial results looked like MST was twice as fast in browsers as it was in node. This was a methodology error. I was bundling the code for web, but not bundling for node. I suspect module resolution was taking up some time.

This PR bundles for node, updates some scripts to use that bundling process. Now the results are much closer (I'm seeing 16k ops/sec on model creation in node, and 20k ops/sec in web. Before it was 9k for node and 20k for web).