### PR TITLE
feat: add more robust run scripts/outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build": "rm -rf build/* && webpack --config webpack.config.cjs",
-    "test:node": "npm run build && echo '\nRunning the node tests, this may take a while...\n' && rm -rf ./results/node-results.csv && node ./build/index.node.bundle.js | tee ./results/node-results.csv",
+    "test:node": "./test-node.sh",
     "test:hermes": "echo 'Hermes not yet supported'",
-    "test:web": "npm run build && echo '\nRunning the web tests, this may take a while...\n' && rm -rf ./results/web-results.csv && node ./puppeteer.cjs | tee ./results/web-results.csv"
+    "test:web": "./test-web.sh"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,8 @@ In order to run the tests here, you'll need:
 
 1. [Node and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) in order to run node scripts and download dependencies with `npm`.
 2. [git](https://git-scm.com/) for source code management.
-3. [tee](https://www.gnu.org/software/coreutils/manual/html_node/tee-invocation.html) (most Mac OS and Linux machines will have this built in).
+3. [bash](https://www.gnu.org/software/bash/), or anything that can run `.sh` files
+4. Some GNU tools that most Mac OS and Linux systems should have built in: [tee](https://www.gnu.org/software/coreutils/manual/html_node/tee-invocation.html), [date](https://www.gnu.org/software/coreutils/manual/html_node/Examples-of-date.html), [grep](https://www.gnu.org/software/grep/), [tail](https://www.gnu.org/software/coreutils/manual/html_node/tail-invocation.html), [awk](https://www.gnu.org/software/gawk/manual/gawk.html), [sed](https://www.gnu.org/software/sed/), [echo](https://www.gnu.org/software/coreutils/manual/html_node/echo-invocation.html), [rm](https://www.gnu.org/software/coreutils/manual/html_node/rm-invocation.html).
 
 ## Setup and running tests
 
@@ -19,7 +20,17 @@ npm run test:web # just test web
 npm run test:hermes # just test Hermes (not yet supported)
 ```
 
-Each one of these commands will write its output to `results/<platform>-results.csv`. Each scenario has a title, which should provide a short description of what it demonstrates. Then we use [Benchmark.js](https://benchmarkjs.com/) to get the operations per second of that scenario, along with the margin of error and number of runs used to reach statistical significance.
+Each one of these commands will write its output to `results/<mst-version>-<timestamp>-<platform>-results.csv`. Each scenario has a title, which should provide a short description of what it demonstrates. We use [Benchmark.js](https://benchmarkjs.com/) to get the operations per second of that scenario, along with the margin of error and number of runs used to reach statistical significance. The last column of the result is the maximum memory usage during testing for that scenario, in bytes.
+
+### Changing MST versions
+
+If you want to run the suite against different versions of MST, before you run tests, you can:
+
+```sh
+npm install mobx-state-tree@desired-version --save
+```
+
+And your output file will write the version number in the file name to make it easy to keep track of.
 
 ## How to add scenarios
 

--- a/test-node.sh
+++ b/test-node.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Get the current day and time 
+now=$(date +"%Y-%m-%dT%H:%M:%S")
+
+# Check the package-lock.json file for the version of mobx-state-tree
+mst_version=$(grep -A 1 '"mobx-state-tree":' package-lock.json | tail -n 1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')
+echo "The installed version of mobx-state-tree is $mst_version"
+npm run build
+echo -e "\nRunning the node tests, this may take a while...\n"
+rm -rf ./results/node-results.csv
+node ./build/index.node.bundle.js | tee ./results/"$mst_version"-"$now"-node-results.csv
+

--- a/test-web.sh
+++ b/test-web.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Get the current day and time 
+now=$(date +"%Y-%m-%dT%H:%M:%S")
+
+# Check the package-lock.json file for the version of mobx-state-tree
+mst_version=$(grep -A 1 '"mobx-state-tree":' package-lock.json | tail -n 1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')
+echo "The installed version of mobx-state-tree is $mst_version"
+npm run build
+echo -e "\nRunning the node tests, this may take a while...\n"
+rm -rf ./results/node-results.csv
+node ./puppeteer.cjs | tee ./results/"$mst_version"-"$now"-web-results.csv
+


### PR DESCRIPTION
Ok, so this sort of closes https://github.com/coolsoftwaretyler/mst-performance-testing/issues/12, because it embeds the current version of MobX-State-Tree in the repo in the output.

So if you want to:

```sh
npm install mobx-state-tree@desired-version --save
```

Then run the tests, you'll get the version in the file name for the output. I think this is sufficient for now.