### PR TITLE
NO MERGE - demonstrate benchmarks actually measure meaningful information

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -75,6 +75,13 @@ for (const scenario in Scenarios) {
   const { title, run } = Scenarios[scenario];
   suite.add(title, () => {
     const startMemory = getStartMemory();
+    const data = [];
+
+    // Create a busy-wait loop to introduce a delay
+    for (let i = 0; i < 10000000; i++) {
+      // This loop will take some time to completeo
+      data.push({ value: i });
+    }
     run();
     const endMemory = getEndMemory();
     const memoryUsed = endMemory - startMemory;


### PR DESCRIPTION
I wanted to validate that the benchmarks are actually measuring real signal.

In this PR, I introduce an arbitrary for loop that pushes data into an array 10000000 times.

If you pull this branch and run `npm run test:node` (or any of the other platforms), you'll get results like:

```
scenario,ops_per_sec,margin_of_error,runs,max_memory_used_kb
Create 1 model,1.3987577775200826,20.340930693425165,8,626096688
Create 1 model and set a float value,1.543987561991318,20.226964125681242,8,606190704
Create 1 model and set a boolean value,1.4876738370472165,24.19704700596701,8,606193048
Create 1 model and set a date value,1.482396220423004,24.660496661000426,8,606020680
Create a types.string,1.594916731297182,23.828707646541616,9,606090184
Create a types.number,1.649352544047359,29.181939089819892,9,606032360
Create a types.integer,1.569156816254096,17.810794782153867,9,606056136
Create a types.float,1.7585003906636596,27.47296967674835,9,606195448
Create a types.boolean,1.7882979483354784,22.24059318327983,9,606186656
Create a types.Date,1.77063090079126,27.72430475278842,9,606186664
Create a types.array(types.string),2.045631127587892,25.86807024498138,9,606219576
Create 10 models,1.9490013977549374,29.81902554454303,9,606195496
Create a types.array(types.number),1.9324892117104195,27.403676523137037,9,606195504
Create a types.array(types.integer),1.9623662776516386,19.00171348702935,9,606230424
Create a types.array(types.float),1.6904710949082875,20.651961028172476,8,606195504
Create a types.array(types.boolean),1.4521278211932052,19.118152862300892,9,606068896
Create a types.array(types.Date),2.091863869453107,25.158973558858467,9,606195504
Create a types.map(types.string),2.028014612591593,23.02291167136884,9,606195448
Create a types.map(types.number),1.847847277837007,23.76572107640571,9,606195464
Create a types.map(types.integer),1.8779733180793603,25.8634821680159,9,606195496
Create a types.map(types.float),2.0791100145408494,20.64867133584211,9,606195464
Create a types.map(types.boolean),1.561672744532145,19.296346423082653,9,606059880
Create 100 models,1.561173161640292,18.59131060379988,9,609302872
Create a types.map(types.Date),1.9110213234587583,30.330090043749998,9,606238608
Create 1,000 models,1.5838008892560915,27.39618422400884,8,666791776
Create 10,000 models,0.8353396117375019,17.07320408249565,7,673311864
Create 100,000 models,0.142589027103694,2.957891052890228,5,667790880
Create 1 model and set a string value,1.5440991844768102,19.948425015115866,9,658018216
Create 1 model and set a number value,1.8648731215990104,30.256495561873876,9,606195784
Create 1 model and set an integer value,2.0638443711536563,29.566639190062183,9,606195472
```

Compare to the `main` branch, where results look like:

```
scenario,ops_per_sec,margin_of_error,runs,max_memory_used_kb
Create 1 model,13014.732063036232,2.8953681813692156,79,275584
Create 1 model and set a float value,10685.24645745029,2.5084985454977713,83,292984
Create 1 model and set a boolean value,11118.554687614818,1.19458986576375,91,278992
Create 1 model and set a date value,10776.731310113732,1.4697050691786924,86,251232
Create a types.string,66774.63774744779,1.2855064053160998,93,1104
Create a types.number,66103.87958613852,0.9191640600337362,91,70952
Create a types.integer,65978.06090138434,1.1422637934509727,92,19328
Create a types.float,65473.22255736505,0.9888848066550477,93,1072
Create a types.boolean,62179.43814734267,2.8977223859720436,86,42432
Create a types.Date,55456.21771059669,3.183057438292827,81,33384
Create a types.array(types.string),23309.476001810093,3.8511065406167324,83,261368
Create 10 models,1699.1809514147958,1.4058276867225847,92,302392
Create a types.array(types.number),28024.230610591847,0.9471583475025055,91,66496
Create a types.array(types.integer),26897.29292038601,1.1262023716072531,88,41848
Create a types.array(types.float),27526.587259395255,1.2072319740539608,90,322064
Create a types.array(types.boolean),28369.59580093686,0.7192668375193992,93,29856
Create a types.array(types.Date),27753.86893814016,1.6078300439426565,93,34320
Create a types.map(types.string),27804.850740498023,1.1007459602339862,92,140368
Create a types.map(types.number),27661.01852795425,1.4897015848554716,88,58440
Create a types.map(types.integer),28305.770122172693,0.7357853592658969,93,17136
Create a types.map(types.float),28186.523007583026,0.7833237105676072,93,25240
Create a types.map(types.boolean),27861.808790466224,0.9469095802150521,93,22544
Create 100 models,179.21422080378773,0.7205463768417073,83,2771984
Create a types.map(types.Date),27853.59087874208,0.7856804081591426,95,45088
Create 1,000 models,17.563754504155323,1.4020035691796267,48,11187640
Create 10,000 models,1.6721751951210417,8.076850821789638,9,11473984
Create 100,000 models,0.17294782709333423,0.6576708802791579,5,-858632
Create 1 model and set a string value,10642.667695552282,1.0116346702745087,89,66160
Create 1 model and set a number value,10924.868286736495,0.7891854868486203,92,38128
Create 1 model and set an integer value,10748.687629718965,0.8744316363103309,90,38768
```

This experiment makes me feel pretty good about what we're measuring. My intentional slowdown and memory usage is getting clocked.

Leaving this PR open for posterity.