### PR TITLE
feat; add array insertion scenarios

### DIFF
--- a/scenarios/array-operations.js
+++ b/scenarios/array-operations.js
@@ -1,0 +1,26 @@
+import { types } from "mobx-state-tree";
+
+const SampleModel = types.model({
+  name: types.string,
+  id: types.string,
+});
+
+const SampleStore = types
+  .model({
+    items: types.array(SampleModel),
+  })
+  .actions((self) => ({
+    add(name, id) {
+      self.items.push({ name, id });
+    },
+  }));
+
+/**
+ * Requested by the community in https://github.com/coolsoftwaretyler/mst-performance-testing/issues/26
+ */
+export const addNObjectsToArray = (n) => {
+  const store = SampleStore.create({ items: [] });
+  for (let i = 0; i < n; i++) {
+    store.add(`item-${i}`, `id-${i}`);
+  }
+};

--- a/scenarios/index.js
+++ b/scenarios/index.js
@@ -18,6 +18,7 @@ import {
   getViewWithParameter,
   getViewWithParameterTwice,
 } from "./derived-values.js";
+import { addNObjectsToArray } from "./array-operations.js";
 /**
  * Below, write scenarios. Each scenario should be exported.
  * It should be an object with a title, descriptoin, and a function.
@@ -770,5 +771,51 @@ export const scenario53 = {
   title: "Get a view with a parameter twice (not cached)",
   run: () => {
     getViewWithParameterTwice();
+  },
+};
+
+/**
+ * Different permutations of a requested benchmark from
+ * https://github.com/coolsoftwaretyler/mst-performance-testing/issues/26
+ */
+export const scenario54 = {
+  title: "Add 1 object to an array",
+  run: () => {
+    addNObjectsToArray(1);
+  },
+};
+
+export const scenario55 = {
+  title: "Add 10 objects to an array",
+  run: () => {
+    addNObjectsToArray(10);
+  },
+};
+
+export const scenario56 = {
+  title: "Add 100 objects to an array",
+  run: () => {
+    addNObjectsToArray(100);
+  },
+};
+
+export const scenario57 = {
+  title: "Add 1,000 objects to an array",
+  run: () => {
+    addNObjectsToArray(1000);
+  },
+};
+
+export const scenario58 = {
+  title: "Add 10,000 objects to an array",
+  run: () => {
+    addNObjectsToArray(10000);
+  },
+};
+
+export const scenario59 = {
+  title: "Add 100,000 objects to an array",
+  run: () => {
+    addNObjectsToArray(100000);
   },
 };


### PR DESCRIPTION
Closes https://github.com/coolsoftwaretyler/mst-performance-testing/issues/26 and takes the idea a little further with tests for `n` insertions, and scenarios for 1, 10, 1,000, 10,000, and 100,000 insertions in the actual suite.

Sequence of commands that should work with this change:

1. `npm run build`
2. `npm run test:node`
3. `npm run test:web`
4. `npm run test:bun`

And these new scenarios should appear in the results CSVs.

The test suite is starting to get pretty long, so I think I'll need to figure out a way to select specific scenarios via CLI moving forward. Otherwise it's just impractical to run everything all at once.
